### PR TITLE
Fixing writing depth image bug after generating depth data with DPT

### DIFF
--- a/preprocess/dpt_depth.py
+++ b/preprocess/dpt_depth.py
@@ -39,8 +39,11 @@ def dpt_depth(cfg, depth_save_dir):
         img_name = img_list[idx]
         depth = DPT_model(img_normalised)
         np.savez(os.path.join(depth_save_dir, 'depth_{}.npz'.format(img_name.split('.')[0])), pred=depth.detach().cpu())
-        imageio.imwrite(os.path.join(depth_save_dir, '{}.png'.format(img_name.split('.')[0])), depth[0].detach().cpu())
-        
+        depth_array = depth[0].detach().cpu().numpy()
+        imageio.imwrite(os.path.join(
+            depth_save_dir, 
+            '{}.png'.format(img_name.split('.')[0])), 
+            np.clip(255.0 / depth_array.max() * (depth_array - depth_array.min()), 0, 255).astype(np.uint8))        
  
                                                                 
 if __name__=='__main__':


### PR DESCRIPTION
During processing my own dataset with preprocess script, the original script always fails at writing depth image, reporting "cannot write mote F as PNG" from imageio.imwrite function. Turns out depth image is a float array generated from DPT, and can not be directly wrote to png file. 

Also the depth image is not normalized, if directly converting to uint8, the depth image will have very low contrast.

Upon the above error, the pre-processing is broken due to exception and resulting depth image is not correctly generated. Therefore proposing two changes:
1. Change depth image data to uint8 format for png writing
2. Renormalizing depth image data to range 0-255 for high contrast.